### PR TITLE
[Niyas][Issue] Solved Issue #7

### DIFF
--- a/backend/src/routes/steam.routes.js
+++ b/backend/src/routes/steam.routes.js
@@ -63,7 +63,14 @@ router.get('/friends', authMiddleWare, async (req, res) => {
         return res.status(200).json(filteredFriends)
     
     } catch (err) {
-        console.error(err);
+        console.log(err);
+
+        if (err.response.status === 401) {
+            return res.status(400).json({
+                message: "Steam Profile Private!"
+            })
+        }
+
         return res.status(500).json({
             message: "Internal server error!"
         })
@@ -103,6 +110,13 @@ router.get('/recent/:username?', userAttach, async (req, res) => {
     
     } catch (err) {
         console.error(err);
+
+        if (err.response.status === 401) {
+            return res.status(400).json({
+                message: "Steam Profile Private!"
+            })
+        }
+        
         return res.status(500).json({
             message: "Internal server error!"
         })

--- a/frontend/src/components/profilebar/Profilebar.tsx
+++ b/frontend/src/components/profilebar/Profilebar.tsx
@@ -17,7 +17,11 @@ export default function Profilebar({ username }: { username: string}) {
             setUserData(res.data)
         })
         .catch((err) => {
-            console.log(err)
+            setUserData({
+                avatarfull: '',
+                personaname: 'User',
+                personastate: 0
+            })
         })
     }, [])
 

--- a/frontend/src/containers/home/Home.tsx
+++ b/frontend/src/containers/home/Home.tsx
@@ -49,6 +49,10 @@ function getTimeCreated(response: any) {
 export default function Home() {
     
     const { globalUsername, isLoggedIn, handleSignOut } = useAppWrapperContext()
+
+    const [privateSteam, setPrivateSteam] = useState(false)
+    const [invalidSteam, setInvalidSteam] = useState(false)
+
     const [mobileNavbar, setMobileNavbar] = useState(false)
     const [loading, setLoading] = useState(true)
     const [friends, setFriends] = useState([])
@@ -72,7 +76,20 @@ export default function Home() {
                 setFriends(res2.data)
                 setRecentGames(res3.data.games)
             }))
-            .catch(() => navigate('/'))
+            .catch((err) => {
+                if (err.response.data.message === "Steam Profile Private!") {
+                    setPrivateSteam(true)
+                    setResult({
+                        steamid: "Profile Private"
+                    })
+                } else {
+                    setInvalidSteam(true)
+                    setResult({
+                        steamid: "Invalid Profile"
+                    })
+                }
+                
+            })
             .finally(() => setLoading(false))
         } catch (err) {
              navigate('/')
@@ -108,7 +125,7 @@ export default function Home() {
                                 <span className="home__type-bg">Your Steam Was&nbsp;</span>
                                 <span className="home__type-writed-text link">
                                     <Typewriter 
-                                        words={words}
+                                        words={ invalidSteam ? ["Not Found. Please Check your Steam-ID, and Try Again."] : privateSteam ? ["Suspected to be Private, Change Visibility to Public."]: words}
                                         loop={0}
                                         cursor
                                         cursorStyle='_'
@@ -133,7 +150,7 @@ export default function Home() {
                                         <Steambar friend={friend} />
                                     ))
                                     :
-                                    <Nothing text="Try getting more friends!"/>
+                                    <Nothing text={invalidSteam ? "Your Steam-ID Does not Exist." : privateSteam ? "Your Steam Profile is Private!" : "Try getting more friends!"}/>
                                 }
                             </div>
                         </div>   
@@ -155,7 +172,7 @@ export default function Home() {
                                     </div>  
                                 ))
                                 :
-                                <Nothing text="Play more to get something here!"/>
+                                <Nothing text={invalidSteam ? "Your Steam-ID Does not Exist." : privateSteam ? "Your Steam Profile is Private!" : "Play more to get something here!"} />
                             }
                         </div>
                     </div>

--- a/frontend/src/containers/xycard/Xycard.tsx
+++ b/frontend/src/containers/xycard/Xycard.tsx
@@ -15,6 +15,7 @@ import Nothing from "../../components/nothing/nothing";
 export default function Xycard() {
 
     const [loading, setLoading] = useState<boolean>(true)
+    const [invalidSteam, setInvalidSteam] = useState(false)
     const navigate = useNavigate()
     const xycardRef = useRef<any>()
     const { user } = useParams()
@@ -32,8 +33,11 @@ export default function Xycard() {
         .catch((err) => {
             if (err.response.status === 400) {
                 navigate('../404')
-            }
-            console.log(err.response.data.message)
+            } 
+            setInvalidSteam(true)
+        })
+        .finally(() => {
+            setLoading(false)
         })
     }, [])
 
@@ -78,7 +82,7 @@ export default function Xycard() {
                             </div>
                         ) : (
                             <div className="xycard__no-games">
-                                <Nothing text="Play more to get something here!"/>
+                                <Nothing text={ invalidSteam ? "Your Steam-ID Does not Exist.": "Play more to get something here!"}/>
                             </div>
                         )
                     }


### PR DESCRIPTION
# Description

- Added a check in the server, to identify if the `SteamAPI` returns a status code of `401`. 
- This thus sends an `400` status code error back to the user if the profile is private. 
- Validated in frontend, for the error status code from the backend, is used to identify if the `SteamID` is private/invalid.
- According text messages are placed on the `Not Found` Components.

Fixes #7 

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Locally Tested
- [ ] Needs Testing From Production
