### PR TITLE
[Niyas] Introducing Context For INVALID/PRIVATE Profiles

### DIFF
--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -6,14 +6,20 @@ import './AppWrapper.css'
 interface AppWrapperContextType {
   isLoggedIn : boolean,
   globalUsername: string,
+  privateSteam: boolean,
+  invalidSteam: boolean,
   setIsLoggedIn? : Dispatch<SetStateAction<boolean>>,
   setGlobalUsername?: Dispatch<SetStateAction<string>>,
+  setPrivateSteam?: Dispatch<SetStateAction<boolean>>,
+  setInvalidSteam?: Dispatch<SetStateAction<boolean>>
   handleSignOut?: () => void;
 }
 
 const defaultValue = {
   isLoggedIn: false,
-  globalUsername: ''
+  globalUsername: '',
+  privateSteam: false,
+  invalidSteam: false
 }
 
 const AppWrapperContext = createContext<AppWrapperContextType>(defaultValue)
@@ -25,11 +31,15 @@ function AppWrapper({ children }: { children: React.ReactNode }) {
 
   const [isLoggedIn, setIsLoggedIn] = useState(defaultValue.isLoggedIn)
   const [globalUsername, setGlobalUsername] = useState(defaultValue.globalUsername)
+  const [privateSteam, setPrivateSteam] = useState(false)
+  const [invalidSteam, setInvalidSteam] = useState(false)
 
 
   const ResetAppContext = () => {
     setGlobalUsername(defaultValue.globalUsername)
     setIsLoggedIn(defaultValue.isLoggedIn)
+    setPrivateSteam(defaultValue.privateSteam)
+    setInvalidSteam(defaultValue.invalidSteam)
   }
 
   const handleSignOut = () => {
@@ -48,7 +58,18 @@ function AppWrapper({ children }: { children: React.ReactNode }) {
     axios.get('https://xylium.onrender.com/api/checkauth')
     .then((res) => {
       setGlobalUsername!(res.data.message ? res.data.message : '')
-      setIsLoggedIn(true)
+      axios.get('https://xylium.onrender.com/user/person/me')
+      .then((res) => {
+        if (res.data.communityvisibilitystate !== 3) {
+          setPrivateSteam!(true)
+        }
+      })
+      .catch((err) => {
+        setInvalidSteam!(true)
+      })
+      .finally(() => {
+        setIsLoggedIn(true)
+      })
     })
     .catch(() => {
       localStorage.removeItem("accessToken")
@@ -63,8 +84,12 @@ function AppWrapper({ children }: { children: React.ReactNode }) {
       value = {{
         isLoggedIn,
         globalUsername,
+        privateSteam,
+        invalidSteam,
         setIsLoggedIn,
         setGlobalUsername,
+        setPrivateSteam,
+        setInvalidSteam,
         handleSignOut
       }}
     >

--- a/frontend/src/containers/download/Download.tsx
+++ b/frontend/src/containers/download/Download.tsx
@@ -18,9 +18,7 @@ const Download = React.forwardRef((props: any, ref: any) => {
         .then((res) => {
             setUserData(res.data)
         })
-        .catch((err) => {
-            console.log(err)
-        })
+        .catch(() => {})
     }, [])
 
     return (

--- a/frontend/src/containers/home/Home.tsx
+++ b/frontend/src/containers/home/Home.tsx
@@ -48,10 +48,9 @@ function getTimeCreated(response: any) {
 
 export default function Home() {
     
-    const { globalUsername, isLoggedIn, handleSignOut } = useAppWrapperContext()
+    const { globalUsername, isLoggedIn, privateSteam, invalidSteam, handleSignOut } = useAppWrapperContext()
 
-    const [privateSteam, setPrivateSteam] = useState(false)
-    const [invalidSteam, setInvalidSteam] = useState(false)
+    
 
     const [mobileNavbar, setMobileNavbar] = useState(false)
     const [loading, setLoading] = useState(true)
@@ -65,6 +64,10 @@ export default function Home() {
     //https://xylium.onrender.com
     //http://localhost:8080
     useEffect(() => {
+        if (privateSteam || invalidSteam) {
+            setLoading(false)
+            return
+        }
         try {
             axios.all([ 
                 axios.get('https://xylium.onrender.com/user/person/me'),
@@ -76,20 +79,7 @@ export default function Home() {
                 setFriends(res2.data)
                 setRecentGames(res3.data.games)
             }))
-            .catch((err) => {
-                if (err.response.data.message === "Steam Profile Private!") {
-                    setPrivateSteam(true)
-                    setResult({
-                        steamid: "Profile Private"
-                    })
-                } else {
-                    setInvalidSteam(true)
-                    setResult({
-                        steamid: "Invalid Profile"
-                    })
-                }
-                
-            })
+            .catch(() => {})
             .finally(() => setLoading(false))
         } catch (err) {
              navigate('/')
@@ -120,7 +110,7 @@ export default function Home() {
                     <div className="home__first">
                         <div className="home__profile">
                             <span className="home__username">{globalUsername}</span>
-                            <span className="home__steamid">{result.steamid}</span>
+                            <span className="home__steamid">{privateSteam ? "Profile Private" : invalidSteam ? "Profile Invalid" : result.steamid}</span>
                             <div className="home__type-writer">
                                 <span className="home__type-bg">Your Steam Was&nbsp;</span>
                                 <span className="home__type-writed-text link">

--- a/frontend/src/containers/landing/Landing.tsx
+++ b/frontend/src/containers/landing/Landing.tsx
@@ -21,7 +21,7 @@ export default function Landing() {
 
     useEffect(() => {
         fetch('https://xylium.onrender.com/server')
-        .then((res) => console.log(res))
+        .then(() => {})
     }, [])
     
     return (


### PR DESCRIPTION
# Description

- Instead of manually checking for `Invalid/Private` profiles using endpoints, it has been activated that context is used to monitor if **the logged in user is invalid/private.** 
- But, `XYCARD'`s visibility and access doesn't need the Private/Invalid profile check since it can be of **any user's card**. Therefore it's not applied there. 


## Type of change

Delete irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Locally Tested
