### PR TITLE
[Niyas][Feature] Implemented Feature #45 - Placeholder Images for XYCARD, Friends

### DIFF
--- a/frontend/src/components/dfriendbar/DFriendBar.tsx
+++ b/frontend/src/components/dfriendbar/DFriendBar.tsx
@@ -8,6 +8,8 @@ function unixTimestampToYear(timestamp: number) {
     return date.getFullYear();
 }
   
+export const defaultBlank = "https://avatars.steamstatic.com/fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb_full.jpg"
+export const backupImage = "https://cdn.discordapp.com/attachments/946407954180108328/1098973545431826472/sport_184_184_px.png"
 
 export default function DFriendBar({ friend }: { friend : any}) {
     
@@ -15,7 +17,7 @@ export default function DFriendBar({ friend }: { friend : any}) {
     const [holder, setHolder] = useState({
         personaname: "Loading",
         steamid: 'Loading',
-        avatarfull: 'https://cdn.discordapp.com/attachments/946407954180108328/1098973545431826472/sport_184_184_px.png'
+        avatarfull: backupImage
     })
 
     useEffect(() => {
@@ -32,7 +34,11 @@ export default function DFriendBar({ friend }: { friend : any}) {
             initial={{ opacity: 0.2 }}
             animate={ loading ? { opacity: 0.2 } : { opacity: 1 }}
         >
-            <img src={holder.avatarfull} alt="" className="df-bar__icon" />
+            <img 
+                src={holder.avatarfull === defaultBlank ? backupImage : holder.avatarfull} 
+                alt="Profile Picture" 
+                className="df-bar__icon" 
+            />
             <div className="df-bar__friend">
                 <div className="df-bar__title">
                     {holder.personaname ? holder.personaname : 'Loading'}

--- a/frontend/src/components/profilebar/Profilebar.tsx
+++ b/frontend/src/components/profilebar/Profilebar.tsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import React, { useEffect, useState } from "react";
 import './Profilebar.css'
+import { backupImage, defaultBlank } from "../dfriendbar/DFriendBar";
 
 export default function Profilebar({ username }: { username: string}) {
     
@@ -31,7 +32,7 @@ export default function Profilebar({ username }: { username: string}) {
                 {userData.personaname}
             </div>
             <div className="pbar__image">
-                <img src={!userData.avatarfull || userData.avatarfull === '' ? 'https://cdn.discordapp.com/attachments/946407954180108328/1098973545431826472/sport_184_184_px.png' : userData.avatarfull} alt="profile picture"/>
+                <img src={!userData.avatarfull || userData.avatarfull === '' || userData.avatarfull === defaultBlank ? backupImage : userData.avatarfull} alt="Profile Picture"/>
                 <div className={`pbar__indicator ${userData.personastate === 0 ? 'pbar__indicator--away': 'pbar__indicator--online'}`}></div>
             </div>
         </div>


### PR DESCRIPTION
# Description

- The current implementation of the images, allows Steam's blank images for output in Friends, XYCARD Section.
- The Placeholder images were placed based on comparison according to steam's default blank image.

Fixes #45 

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Locally Tested
