### PR TITLE
[Niyas][Feature] Implemented Feature #62 - Linked Popover Endpoints

### DIFF
--- a/frontend/src/containers/settings/Settings.data.ts
+++ b/frontend/src/containers/settings/Settings.data.ts
@@ -2,18 +2,15 @@ import { Actions, PopoverProps } from "../../components/popover/Popover"
 
 export const emailPopover: PopoverProps = {
     label: "Enter your E-Mail",
-    operation: Actions.save,
-    onComplete: () => {}
+    operation: Actions.email
 }
 
 export const passwordPopover: PopoverProps = {
     label: "Enter your Password",
-    operation: Actions.save,
-    onComplete: () => {}
+    operation: Actions.pass
 }
 
 export const deletePopover: PopoverProps = {
     label: 'TYPE IN "DELETE" To Confirm',
-    operation: Actions.del,
-    onComplete: () => {}
+    operation: Actions.del
 }

--- a/frontend/src/containers/settings/Settings.tsx
+++ b/frontend/src/containers/settings/Settings.tsx
@@ -126,9 +126,9 @@ export default function Settings() {
                 >
                     <Popover 
                         label={popoverOpen.label || ""}
-                        operation={popoverOpen.operation || Actions.save} 
+                        operation={popoverOpen.operation || Actions.email} 
                         onCancel={handleClose}
-                        onComplete={popoverOpen.onComplete|| null}
+                        onComplete={handleClose}
                     />
                 </motion.div>
             }


### PR DESCRIPTION
# Description

- Built handlers to describe, and connect the popovers to their respective backend endpoints.
- Any failure over the endpoints will initiate the snackbar for the user to identify the issue.
- All successful attempts will open `success` snackbars and close the popover.

Fixes #62 

## Type of change

Delete irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Locally Tested
