### PR TITLE
[Niyas][Feature] Implemented Feature #69 - Backend endpoints for `/forgotpassword`, `/resetpassword`

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.0.3"
+    "mongoose": "^7.0.3",
+    "nodemailer": "^6.9.4"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/backend/src/configs/email.configs.js
+++ b/backend/src/configs/email.configs.js
@@ -1,0 +1,13 @@
+const nodemailer = require('nodemailer')
+
+const transporter = nodemailer.createTransport({
+    service: "Hotmail",
+    auth: {
+        user: process.env.EMAIL,
+        pass: process.env.PASS
+    },
+    maxConnections: 5,
+    rateLimit: 5000
+})
+
+module.exports = transporter


### PR DESCRIPTION
# Description

- Implemented two endpoints, based on the requirements specified over the issue.
- They can be accessed over `/api/forgotpassword`, `/api/resetpassword`
- `/forgotpassword` POST request accepts the e-mail from the body, generate a signed token and lay it out in a link to the user via mail.
- And `/resetpassword` POST ensures the signed token, decodes it and changes the password with the body.


Fixes #69 

## Type of change

Delete irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Locally Tested
